### PR TITLE
feat: Improve sidebar and context menu UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+# Keep environment variables out of version control
+.env
+
+/generated/prisma

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,15 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/webnotes/src/app/api/notes/[id]/route.ts
+++ b/webnotes/src/app/api/notes/[id]/route.ts
@@ -19,12 +19,23 @@ export async function PUT(
   const { id } = await params;
 
   const { htmlContent, textContent } = await request.json();
-  const title = (textContent?.split('\n')[0]?.trim() || 'New Note').slice(0, 200);
+  
+  // Fetch the current note to check its title
+  const currentNote = await prisma.note.findUnique({
+    where: { id }
+  });
+
+  let titleToUpdate = currentNote?.title;
+  
+  // Only update the title if it's still the default "New Note" or empty
+  if (currentNote && (currentNote.title === 'New Note' || !currentNote.title)) {
+    titleToUpdate = (textContent?.split('\n')[0]?.trim() || 'New Note').slice(0, 200);
+  }
 
   try {
     const result = await prisma.note.updateMany({
       where: { id, userId }, // Ensures ownership
-      data: { title, content: htmlContent, updatedAt: new Date() },
+      data: { title: titleToUpdate, content: htmlContent, updatedAt: new Date() },
     });
 
     if (result.count === 0) {

--- a/webnotes/src/app/components/Sidebar.tsx
+++ b/webnotes/src/app/components/Sidebar.tsx
@@ -22,9 +22,8 @@ interface SidebarProps {
   activeNoteId: string | null;
   setActiveNoteId: (id: string) => void;
   createNote: (folderId?: string | null) => void;
-  deleteNote: (id: string) => void;
   moveNote: (noteId: string, folderId: string | null) => void;
-  createFolder: () => void;
+  createFolder: () => Promise<{ id: string; name: string } | null>; // Modified to return folder object
   onDataChange: () => void;
 }
 
@@ -34,13 +33,23 @@ export default function Sidebar({
   activeNoteId, 
   setActiveNoteId, 
   createNote,
-  deleteNote,
   moveNote,
   createFolder,
   onDataChange
 }: SidebarProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+  
+  
+  const [newlyCreatedFolder, setNewlyCreatedFolder] = useState<{ id: string; name: string } | null>(null);
+  
+  const handleCreateFolder = async () => {
+    const newFolder = await createFolder();
+    if (newFolder) {
+      setNewlyCreatedFolder(newFolder);
+      // Don't call onDataChange immediately - let the NoteList handle it after rename
+    }
+  };
 
   useEffect(() => {
     const saved = localStorage.getItem('expandedFolders');
@@ -104,27 +113,33 @@ export default function Sidebar({
         <div className={`p-2 border-b border-zinc-800 flex items-center ${ isOpen ? 'flex-row justify-around' : 'flex-col justify-start gap-2' }`}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={() => createNote()}>
+              <Button variant="ghost" size="icon" onClick={() => createNote()} className="hover:bg-zinc-700">
                 <FilePlus size={18} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="right"><p>New Note</p></TooltipContent>
+            <TooltipContent side="bottom" sideOffset={0} className="px-2 py-1 text-xs">
+              <p>New Note</p>
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={createFolder}>
+              <Button variant="ghost" size="icon" onClick={handleCreateFolder} className="hover:bg-zinc-700">
                 <FolderPlus size={18} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="right"><p>New Folder</p></TooltipContent>
+            <TooltipContent side="bottom" sideOffset={0} className="px-2 py-1 text-xs">
+              <p>New Folder</p>
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" className="hover:bg-zinc-700">
                 <Search size={18} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="right"><p>Search</p></TooltipContent>
+            <TooltipContent side="bottom" sideOffset={0} className="px-2 py-1 text-xs">
+              <p>Search</p>
+            </TooltipContent>
           </Tooltip>
         </div>
 
@@ -140,6 +155,8 @@ export default function Sidebar({
               toggleFolder={toggleFolder}
               moveNote={moveNote}
               onDataChange={onDataChange}
+              newlyCreatedFolder={newlyCreatedFolder}
+              clearNewlyCreatedFolder={() => setNewlyCreatedFolder(null)}
               // Removed deleteNote - it's handled by onDataChange in NoteList
             />
           </div>

--- a/webnotes/src/app/components/context-menu.tsx
+++ b/webnotes/src/app/components/context-menu.tsx
@@ -62,7 +62,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-zinc-800 p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
         className
       )}
       {...props}
@@ -80,7 +80,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 hover:bg-zinc-700",
       inset && "pl-8",
       className
     )}

--- a/webnotes/src/app/page.tsx
+++ b/webnotes/src/app/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [fetchData]);
   
   const handleDataChange = useCallback(() => { 
     fetchData(); 
@@ -72,20 +72,7 @@ export default function Home() {
     }
   };
 
-  const deleteNote = async (id: string) => {
-    const originalNotes = [...notes];
-    const newNotes = notes.filter((note) => note.id !== id);
-    setNotes(newNotes);
-    if (activeNoteId === id) setActiveNoteId(newNotes.length > 0 ? newNotes[0].id : null);
-    
-    const res = await fetch(`/api/notes/${id}`, { method: 'DELETE' });
-    if (!res.ok) {
-      setNotes(originalNotes);
-      toast.error("Failed to delete note.");
-    } else {
-      handleDataChange();
-    }
-  };
+  
 
   const moveNote = async (noteId: string, folderId: string | null) => {
     const originalNotes = [...notes];
@@ -106,15 +93,19 @@ export default function Home() {
   };
 
   const createFolder = async () => {
-    const folderName = prompt("Enter folder name:");
-    if (folderName) {
-      const res = await fetch('/api/folders', { 
-        method: 'POST', 
-        headers: {'Content-Type': 'application/json'}, 
-        body: JSON.stringify({ name: folderName }) 
-      });
-      if (res.ok) handleDataChange();
+  const res = await fetch('/api/folders', { 
+    method: 'POST', 
+    headers: {'Content-Type': 'application/json'}, 
+    body: JSON.stringify({ name: 'New Folder' }) // Create with a default name
+  });
+    
+    if (res.ok) {
+      const { folder } = await res.json(); // Destructure the folder object
+      handleDataChange();
+      // Return the newly created folder object
+      return folder;
     }
+    return null;
   };
 
   const handleNoteUpdate = (updatedNote: Note) => {
@@ -139,7 +130,6 @@ export default function Home() {
           activeNoteId={activeNoteId}
           setActiveNoteId={setActiveNoteId}
           createNote={createNote}
-          deleteNote={deleteNote}
           moveNote={moveNote}
           createFolder={createFolder}
           onDataChange={handleDataChange} // Added this line


### PR DESCRIPTION
This commit introduces several UX improvements to the sidebar and context menu.

- The context menu is now opaque and has a hover effect for better visibility.
- The "New Note", "New Folder", and "Search" buttons now have a hover effect.
- When a new folder is created, the focus is automatically set on the input field for renaming (no dialog box anymore).
- The note title is no longer automatically updated when the body of the note is changed. The title is set the first time you start writing a note. No more popup requests